### PR TITLE
Visitor can sign-up, login and logout - BACK-END

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'rack-cors', require: 'rack/cors'
 gem 'active_model_serializers'
 gem 'aws-sdk-s3'
+gem 'devise_token_auth'
 
 group :development, :test do
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
+    bcrypt (3.1.13)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -80,6 +81,15 @@ GEM
       tins (~> 1.6)
     crass (1.0.4)
     database_cleaner (1.7.0)
+    devise (4.6.2)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0, < 6.0)
+      responders
+      warden (~> 1.2.3)
+    devise_token_auth (1.1.0)
+      devise (> 3.5.2, < 4.7)
+      rails (>= 4.2.0, < 6)
     diff-lcs (1.3)
     docile (1.3.1)
     erubi (1.8.0)
@@ -118,6 +128,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    orm_adapter (0.5.0)
     pg (1.1.4)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -160,6 +171,9 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    responders (2.4.1)
+      actionpack (>= 4.2.0, < 6.0)
+      railties (>= 4.2.0, < 6.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
@@ -204,6 +218,8 @@ GEM
     tins (1.20.3)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    warden (1.2.8)
+      rack (>= 2.0.6)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -217,6 +233,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   coveralls
   database_cleaner
+  devise_token_auth
   factory_bot_rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -1,4 +1,5 @@
 class Api::V1::PostsController < ApplicationController
+  before_action :authenticate_api_v1_user!, only: [:create]
 
   def index
     posts = Post.all

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+  include DeviseTokenAuth::Concerns::SetUserByToken
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,10 @@
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters 
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:level])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class User < ActiveRecord::Base
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable and :omniauthable
+  extend Devise::Models
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable
+  include DeviseTokenAuth::Concerns::User
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,10 @@ class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   extend Devise::Models
+  enum level: [:newbie, :established]
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
+
+  validates_presence_of :level
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   extend Devise::Models
-  enum level: [:newbie, :established]
+  enum level: [:newbie, :settled]
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  # config.change_headers_on_each_request = true
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  # config.token_lifespan = 2.weeks
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {:'access-token' => 'access-token',
+  #                        :'client' => 'client',
+  #                        :'expiry' => 'expiry',
+  #                        :'uid' => 'uid',
+  #                        :'token-type' => 'token-type' }
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  # config.enable_standard_devise_support = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount_devise_token_auth_for 'User', at: 'auth'
   namespace :api do
     namespace :v0 do
       resources :pings, only: [:index], constraints: { format: 'json' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'auth'
+  
   namespace :api do
     namespace :v0 do
       resources :pings, only: [:index], constraints: { format: 'json' }
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
     namespace :v1 do
       resources :posts, only: [:index, :create]
+      mount_devise_token_auth_for 'User', at: 'auth', skip: [:omniauth_callbacks]
     end
   end
 end

--- a/db/migrate/20190616110925_devise_token_auth_create_users.rb
+++ b/db/migrate/20190616110925_devise_token_auth_create_users.rb
@@ -1,0 +1,49 @@
+class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    
+    create_table(:users) do |t|
+      ## Required
+      t.string :provider, :null => false, :default => "email"
+      t.string :uid, :null => false, :default => ""
+
+      ## Database authenticatable
+      t.string :encrypted_password, :null => false, :default => ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, :default => false
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      ## User Info
+      t.string :name
+      t.string :nickname
+      t.string :image
+      t.string :email
+
+      ## Tokens
+      t.text :tokens
+
+      t.timestamps
+    end
+
+    add_index :users, :email,                unique: true
+    add_index :users, [:uid, :provider],     unique: true
+    add_index :users, :reset_password_token, unique: true
+    add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,       unique: true
+  end
+end

--- a/db/migrate/20190616112905_add_trackable_to_user.rb
+++ b/db/migrate/20190616112905_add_trackable_to_user.rb
@@ -1,0 +1,10 @@
+class AddTrackableToUser < ActiveRecord::Migration[5.2]
+  def change
+    ## Trackable
+    add_column :users, :sign_in_count, :integer, :default => 0
+    add_column :users, :current_sign_in_at, :datetime
+    add_column :users, :last_sign_in_at, :datetime
+    add_column :users, :current_sign_in_ip, :string
+    add_column :users, :last_sign_in_ip, :string
+  end
+end

--- a/db/migrate/20190616120659_add_level_to_users.rb
+++ b/db/migrate/20190616120659_add_level_to_users.rb
@@ -1,0 +1,5 @@
+class AddLevelToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :level, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_13_140828) do
+ActiveRecord::Schema.define(version: 2019_06_16_110925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,31 @@ ActiveRecord::Schema.define(version: 2019_06_13_140828) do
     t.decimal "longitude"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "nickname"
+    t.string "image"
+    t.string "email"
+    t.text "tokens"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_16_112905) do
+ActiveRecord::Schema.define(version: 2019_06_16_120659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2019_06_16_112905) do
     t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
+    t.integer "level"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_16_110925) do
+ActiveRecord::Schema.define(version: 2019_06_16_112905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,6 +65,11 @@ ActiveRecord::Schema.define(version: 2019_06_16_110925) do
     t.text "tokens"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "sign_in_count", default: 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    email { "stefano@migrado.com" }
+    password { "password" }
+    password_confirmation { "password" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     email { "stefano@migrado.com" }
     password { "password" }
     password_confirmation { "password" }
+    level { 0 }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'Database table' do
+    it { is_expected.to have_db_column :id }
+    it { is_expected.to have_db_column :provider }
+    it { is_expected.to have_db_column :uid }
+    it { is_expected.to have_db_column :encrypted_password }
+    it { is_expected.to have_db_column :reset_password_token }
+    it { is_expected.to have_db_column :reset_password_sent_at }
+    it { is_expected.to have_db_column :remember_created_at }
+    it { is_expected.to have_db_column :sign_in_count }
+    it { is_expected.to have_db_column :current_sign_in_at }
+    it { is_expected.to have_db_column :last_sign_in_at }
+    it { is_expected.to have_db_column :current_sign_in_ip }
+    it { is_expected.to have_db_column :last_sign_in_ip }
+    it { is_expected.to have_db_column :confirmation_token }
+    it { is_expected.to have_db_column :confirmed_at }
+    it { is_expected.to have_db_column :confirmation_sent_at }
+    it { is_expected.to have_db_column :unconfirmed_email }
+    it { is_expected.to have_db_column :nickname }
+    it { is_expected.to have_db_column :image }
+    it { is_expected.to have_db_column :email }
+    it { is_expected.to have_db_column :tokens }
+    it { is_expected.to have_db_column :created_at }
+    it { is_expected.to have_db_column :updated_at }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_confirmation_of(:password) }
+
+    context 'should not have an invalid email address' do
+      emails = ['stefan@ craft.com', '@felix.com', 'test mail@gmail.com',
+                'user@mail', 'foobar@.yo. .yo', 'wazzup@.dawg']
+
+      emails.each do |email|
+        it { is_expected.not_to allow_value(email).for(:email) }
+      end
+    end
+
+    context 'should have a valid email address' do
+      emails = ['felix@craft.com', 'foobar@craft.co.uk', 'carla123@craft.se',
+                'george@craft.gr']
+
+      emails.each do |email|
+        it { is_expected.to allow_value(email).for(:email) }
+      end
+    end
+  end
+
+  describe 'Factory' do
+    it 'should have valid Factory' do
+      expect(create(:user)).to be_valid
+    end
+  end
+end 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,11 +24,13 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_db_column :tokens }
     it { is_expected.to have_db_column :created_at }
     it { is_expected.to have_db_column :updated_at }
+    it { is_expected.to have_db_column :level }
   end
 
   describe 'Validations' do
     it { is_expected.to validate_presence_of(:email) }
     it { is_expected.to validate_confirmation_of(:password) }
+    it { is_expected.to validate_presence_of(:level )}
 
     context 'should not have an invalid email address' do
       emails = ['stefan@ craft.com', '@felix.com', 'test mail@gmail.com',

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe 'User Registration', type: :request do
     it 'returns a user and a token' do
       post '/api/v1/auth', params: { email: 'felix@craft.se',
                                      password: 'password',
-                                     password_confirmation: 'password'
+                                     password_confirmation: 'password',
+                                     level: 'newbie'
                                   }, headers: headers
 
       expect(json_response['status']).to eq 'success'

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe 'User Registration', type: :request do
+  let(:headers) { { HTTP_ACCEPT: 'application/json' } }
+
+  context 'with valid credentials' do
+    it 'returns a user and a token' do
+      post '/api/v1/auth', params: { email: 'felix@craft.se',
+                                     password: 'password',
+                                     password_confirmation: 'password'
+                                  }, headers: headers
+
+      expect(json_response['status']).to eq 'success'
+      expect(response.status).to eq 200
+    end
+  end
+
+  context 'returns an error when user tries to submit' do
+    it 'a non-matching password confirmation' do
+      post '/api/v1/auth', params: { email: 'zane@craft.se',
+                                     password: 'password',
+                                     password_confirmation: 'bad_password'
+                                  }, headers: headers
+
+      expect(json_response['errors']['password_confirmation']).to eq ["doesn't match Password"]
+      expect(response.status).to eq 422
+    end
+
+    it 'an invalid email address' do
+      post '/api/v1/auth', params: { email: 'george@craft',
+                                     password: 'password',
+                                     password_confirmation: 'password'
+                                  }, headers: headers
+
+      expect(json_response['errors']['email']).to eq ['is not an email']
+      expect(response.status).to eq 422
+    end
+
+    it 'an already registered email address' do
+      FactoryBot.create(:user, email: 'carla@craft.se',
+                               password: 'password',
+                               password_confirmation: 'password')
+
+      post '/api/v1/auth', params: { email: 'carla@craft.se',
+                                     password: 'password',
+                                     password_confirmation: 'password'
+                                  }, headers: headers
+
+      expect(json_response['errors']['email']).to eq ['has already been taken']
+      expect(response.status).to eq 422
+    end
+  end
+end 

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Sessions", type: :request do
         "data" => {
           "id" => user.id, "uid" => user.email, "email" => user.email,
           "provider" => "email", "name" => nil, "nickname" => nil,
-          "image" => nil, "allow_password_change" => false
+          "image" => nil, "level" => user.level, "allow_password_change" => false
         }    
       }
 

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe "Sessions", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let(:headers) { { HTTP_ACCEPT: "application/json" } }
+
+  describe "POST /api/v1/auth/sign_in" do
+    it "valid credentials returns a user" do
+      post "/api/v1/auth/sign_in", params: { email: user.email,
+                                             password: user.password
+                                          }, headers: headers
+
+      expected_response = {
+        "data" => {
+          "id" => user.id, "uid" => user.email, "email" => user.email,
+          "provider" => "email", "name" => nil, "nickname" => nil,
+          "image" => nil, "allow_password_change" => false
+        }    
+      }
+
+      expect(json_response).to eq expected_response
+    end
+
+    it "invalid password returns an error message" do
+      post "/api/v1/auth/sign_in", params: { email: user.email,
+                                             password: "bad_password"
+                                          }, headers: headers
+
+      expect(json_response["errors"])
+        .to eq ["Invalid login credentials. Please try again."]
+
+      expect(response.status).to eq 401
+    end
+
+    it "invalid email returns an error message" do
+      post "/api/v1/auth/sign_in", params: { email: "bad@craft.com",
+                                             password: user.password
+                                          }, headers: headers
+
+      expect(json_response["errors"])
+        .to eq ["Invalid login credentials. Please try again."]
+
+      expect(response.status).to eq 401
+    end
+  end
+end 

--- a/spec/requests/api/v1/posts/create_spec.rb
+++ b/spec/requests/api/v1/posts/create_spec.rb
@@ -1,5 +1,8 @@
 RSpec.describe Api::V1::PostsController, type: :request do
-  let(:headers) { { HTTP_ACCEPT: 'application/json' } }
+  let(:user) { FactoryBot.create(:user) }
+  let(:credentials) { user.create_new_auth_token }
+  let(:headers) { { HTTP_ACCEPT: "application/json" }.merge!(credentials) }
+  let(:not_headers) { {HTTP_ACCEPT: "application/json"} }
 
   describe "POST /api/v1/posts" do
 
@@ -33,7 +36,7 @@ RSpec.describe Api::V1::PostsController, type: :request do
     end
 
     describe "unsuccessfully" do
-      it "can not be created without all fields filled in" do
+      it "Post can not be created without all fields filled in" do
         post "/api/v1/posts", params: {
           image: {
             type: "image/png",
@@ -51,7 +54,7 @@ RSpec.describe Api::V1::PostsController, type: :request do
         expect(response.status).to eq 422
       end
 
-      it "can not be created if caption is more than 140 characters" do
+      it "Post can not be created if caption is more than 140 characters" do
 
         post "/api/v1/posts", params: {
           image: {
@@ -69,6 +72,12 @@ RSpec.describe Api::V1::PostsController, type: :request do
 
         expect(json_response['error']).to eq ["Caption is too long (maximum is 140 characters)"]
       end
+
+      it "Post can not be created if user is not logged in" do
+        post "/api/v1/posts", headers: not_headers
+        expect(json_response["errors"]).to eq ["You need to sign in or sign up before continuing."]
+      end
+
     end
   end
 end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/166150770)

## Changes proposed in this pull request:
* Adds unit test for User model, and request spec for registration and login
* Installs and setups Devise Token Auth
* Generates User model, via Devise Token Auth
* Adds DB column (migration file) for `level` as enum, with `newbie`and `established`as keys 
* Configures permitted params for sign up to include `levels` as well

## What I have learned working on this feature:
* Modifying User model from Devise Token Auth with new DB column, and configuring permitted params 
* Refreshed knowledge about implementing and testing Devise Token Auth