### PR TITLE
User can view her own entry statuses - BACK END

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
---require spec_helper
+--require rails_helper
 --format documentation
 --color

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -7,12 +7,12 @@ class Api::V1::PostsController < ApplicationController
     else
       posts = Post.all
     end
-    render json: posts, each_serializer: Posts::IndexSerializer
+    render json: posts, each_serializer: Posts::Serializer
   end
 
   def show
     post = Post.find(params[:id])
-    render json: post, serializer: Posts::ShowSerializer
+    render json: post, serializer: Posts::Serializer
   end
 
   def create

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -2,7 +2,11 @@ class Api::V1::PostsController < ApplicationController
   before_action :authenticate_api_v1_user!, only: [:create, :update]
 
   def index
-    posts = Post.all
+    if params[:user_id]
+      posts = Post.where(user_id: params[:user_id])
+    else
+      posts = Post.all
+    end
     render json: posts, each_serializer: Posts::IndexSerializer
   end
 

--- a/app/serializers/posts/index_serializer.rb
+++ b/app/serializers/posts/index_serializer.rb
@@ -1,4 +1,0 @@
-class Posts::IndexSerializer < ActiveModel::Serializer
-  attributes :id, :status, :category, :longitude, :latitude
-  belongs_to :user, serializer: Users::Serializer
-end

--- a/app/serializers/posts/serializer.rb
+++ b/app/serializers/posts/serializer.rb
@@ -1,4 +1,4 @@
-class Posts::ShowSerializer < ActiveModel::Serializer
+class Posts::Serializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
 
   attributes :id, :status, :caption, :category, :longitude, :latitude, :created_at

--- a/spec/requests/api/v1/posts/index_spec.rb
+++ b/spec/requests/api/v1/posts/index_spec.rb
@@ -6,12 +6,20 @@ RSpec.describe Api::V1::PostsController, type: :request do
   describe "GET /api/v1/posts" do
 
     before do
-      5.times { FactoryBot.create(:post, user_id: user.id) }
+      5.times do      
+        post = FactoryBot.create(:post, user_id: user.id)
+        post.image.attach(io: File.open('spec/fixtures/dummy_image.jpg'), filename: 'attachment.jpg', content_type: 'image/jpg')
+      end
+
+      4.times do      
+        post = FactoryBot.create(:post, user_id: another_user.id)
+        post.image.attach(io: File.open('spec/fixtures/dummy_image.jpg'), filename: 'attachment.jpg', content_type: 'image/jpg')
+      end
     end
 
     it "returns a collection of posts" do
       get "/api/v1/posts", headers: headers
-      expect(json_response.count).to eq 5
+      expect(json_response.count).to eq 9
     end
 
     it "returns 200 response" do
@@ -22,7 +30,7 @@ RSpec.describe Api::V1::PostsController, type: :request do
     it "has correct keys in the response" do
       get "/api/v1/posts", headers: headers
 
-      posts= Post.all
+      posts = Post.all
 
       posts.each do |post|
         expect(json_response[posts.index(post)]).to include('id')
@@ -33,13 +41,9 @@ RSpec.describe Api::V1::PostsController, type: :request do
     end
 
     describe 'for a specific user' do
-      before do
-        5.times { FactoryBot.create(:post, user_id: user.id) }
-        4.times { FactoryBot.create(:post, user_id: another_user.id) } 
-        get '/api/v1/posts', params: {user_id: another_user.id} 
-      end
-
+      
       it "lists only users posts" do
+        get '/api/v1/posts', params: {user_id: another_user.id} 
         user_posts = Post.where(user_id: another_user.id)
         user_posts.each do |user_post|
           expect(json_response[user_posts.index(user_post)]['user']['id']).to eq another_user.id

--- a/spec/requests/api/v1/posts/index_spec.rb
+++ b/spec/requests/api/v1/posts/index_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Api::V1::PostsController, type: :request do
   let(:user) { FactoryBot.create(:user) }
+  let(:another_user) { FactoryBot.create(:user, email: 'felix@craft.com') }
   let(:headers) { { HTTP_ACCEPT: 'application/json' } }
 
   describe "GET /api/v1/posts" do
@@ -28,6 +29,22 @@ RSpec.describe Api::V1::PostsController, type: :request do
         expect(json_response[posts.index(post)]).to include('status')
         expect(json_response[posts.index(post)]).to include('latitude')
         expect(json_response[posts.index(post)]).to include('longitude')
+      end
+    end
+
+    describe 'for a specific user' do
+      before do
+        5.times { FactoryBot.create(:post, user_id: user.id) }
+        4.times { FactoryBot.create(:post, user_id: another_user.id) } 
+        get '/api/v1/posts', params: {user_id: another_user.id} 
+      end
+
+      it "lists only users posts" do
+        user_posts = Post.where(user_id: another_user.id)
+        user_posts.each do |user_post|
+          expect(json_response[user_posts.index(user_post)]['user']['id']).to eq another_user.id
+        end
+        expect(json_response.count).to eq 4
       end
     end
   end

--- a/spec/requests/api/v1/posts/index_spec.rb
+++ b/spec/requests/api/v1/posts/index_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Api::V1::PostsController, type: :request do
 
     before do
       5.times do      
-        post = FactoryBot.create(:post, user_id: user.id)
-        post.image.attach(io: File.open('spec/fixtures/dummy_image.jpg'), filename: 'attachment.jpg', content_type: 'image/jpg')
+        post_user = FactoryBot.create(:post, user_id: user.id)
+        post_user.image.attach(io: File.open('spec/fixtures/dummy_image.jpg'), filename: 'attachment.jpg', content_type: 'image/jpg')
       end
 
       4.times do      
-        post = FactoryBot.create(:post, user_id: another_user.id)
-        post.image.attach(io: File.open('spec/fixtures/dummy_image.jpg'), filename: 'attachment.jpg', content_type: 'image/jpg')
+        post_another_user = FactoryBot.create(:post, user_id: another_user.id)
+        post_another_user.image.attach(io: File.open('spec/fixtures/dummy_image.jpg'), filename: 'attachment.jpg', content_type: 'image/jpg')
       end
     end
 


### PR DESCRIPTION
## [PT Story](https://www.pivotaltracker.com/story/show/166874980)

### Changes proposed in this PR:
* Request spec for Posts controller `index` action - GET request with a user_id as a param
* Implementation in the Posts controller
* Changed serializer (`index` and `show` become one serializer, as frontend needs all the info even for the posts `index`)
* Updated existing elements of request spec for Posts controller `index` action (to accommodate the new serializer) 